### PR TITLE
Fix: increase countCheckLists attribute afted creating a checklist

### DIFF
--- a/trello/card.py
+++ b/trello/card.py
@@ -769,6 +769,10 @@ class Card(TrelloBase):
             cl.add_checklist_item(name, checked)
 
         self.fetch()
+        try:
+            self.countCheckLists += 1
+        except AttributeError:
+            self.countCheckLists = 1
         return cl
 
     def _set_due_complete(self, is_complete):


### PR DESCRIPTION
When we try to add a checklist to a card using `add_checkist` method in the py-trello library, it doesn't change the card's `countCheckLists` attribute. For this reason, if we try to add a checklist to a card without checklists, we won't be able to validate that the card object has our recently added checklist unless we make a request to the Trello API server

This is a code example:
```python
>>> card.fetch_checklists()
[]
>>> card.countCheckLists
0
>>> card.add_checklist("TEST")
<Checklist 6308958f4aa701008a1a72d4>
>>> card.fetch_checklists()
[]
>>> card.countCheckLists
0
```

I fix this issue in this PR